### PR TITLE
patched to compile with QT 4.6.x

### DIFF
--- a/src/addviewdialog.cpp
+++ b/src/addviewdialog.cpp
@@ -45,7 +45,11 @@ AddViewDialog::AddViewDialog(IrcConnection* connection, QWidget* parent) : QDial
     d.passLabel = new QLabel(this);
     d.passLabel->setText("Password:");
     d.passEdit = new QLineEdit(this);
+    #if QT_VERSION < 0x040700
+    d.passEdit->setToolTip(tr("Optional..."));
+    #else
     d.passEdit->setPlaceholderText(tr("Optional..."));
+    #endif
 
     d.buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this);
     connect(d.buttonBox, SIGNAL(accepted()), this, SLOT(accept()));

--- a/src/gui/messageview.cpp
+++ b/src/gui/messageview.cpp
@@ -48,7 +48,11 @@ MessageView::MessageView(ViewInfo::Type type, IrcConnection* connection, Message
     d.setupUi(this);
     d.viewType = type;
     d.sentId = 1;
+    #if QT_VERSION >= 0x040700
     d.awayReply.invalidate();
+    #else
+    d.awayReply = QTime();
+    #endif
     d.playback = false;
     d.parser = stackView->parser();
     d.firstNames = true;

--- a/src/gui/messageview.h
+++ b/src/gui/messageview.h
@@ -18,7 +18,11 @@
 #include "ui_messageview.h"
 #include "viewinfo.h"
 #include <QPointer>
+#if QT_VERSION >= 0x040700
 #include <QElapsedTimer>
+#else
+#include <QTime>
+#endif
 
 class SyntaxHighlighter;
 class MessageStackView;
@@ -100,7 +104,11 @@ private:
         QString topic;
         int sentId;
         QString awayMessage;
+        #if QT_VERSION >= 0x040700
         QElapsedTimer awayReply;
+        #else
+        QTime awayReply;
+        #endif
         bool playback;
         int joined, parted;
         int connected, disconnected;


### PR DESCRIPTION
There's also some changes in `src/shared/zncmanager.h`:

``````
#if QT_VERSION >= 0x040700
#include <QElapsedTimer>
#else
#include <QTime>
#endif```
+++
``````

``````
    #if QT_VERSION >= 0x040700
    QElapsedTimer timestamper;
    #else
    QTime timestamper;
    #endif```
``````

and in `src/shared/zncmanager.cpp`:

``````
    #if QT_VERSION >= 0x040700
    d.timestamper.invalidate();
    #else
    d.timestamper = QTime();
    #endif```
+++
``````

void ZncManager::onConnected()
{
    #if QT_VERSION >= 0x040700
    d.timestamper.invalidate();
    #else
    d.timestamper = QTime();
    #endif
}```
