### PR TITLE
Allow themes to override nick colors

### DIFF
--- a/src/libs/base/messageformatter.cpp
+++ b/src/libs/base/messageformatter.cpp
@@ -217,10 +217,11 @@ QString MessageFormatter::styledText(const QString& text, Style style) const
     if (style & Bold)
         fmt = tr("<b>%1</b>").arg(fmt);
     if (style & (Color | Dim)) {
-        const int h = qHash(text) % 359;
-        const int s = (style & Dim) ? 0 : 102;
-        const int l = 134;
-        fmt = tr("<font color='%2'>%1</font>").arg(fmt, QColor::fromHsl(h, s, l).name());
+        int bucket = (qHash(text) % 9) + 1;
+        if (style & Dim) {
+            bucket = 0;
+        }
+        fmt = tr("<span class='nick%2'>%1</span>").arg(fmt, QString::number(bucket));
     }
     return fmt;
 }

--- a/themes/cute/cute.css
+++ b/themes/cute/cute.css
@@ -28,6 +28,17 @@ a { color: #4040ff; }
 .lightblue { color: #268bd2;}
 .pink { color: #6c71c4;}
 
+.nick0 { color: hsl(0, 0%, 60%); }
+.nick1 { color: hsl(0, 50%, 60%); }
+.nick2 { color: hsl(40, 50%, 60%); }
+.nick3 { color: hsl(80, 50%, 60%); }
+.nick4 { color: hsl(120, 50%, 60%); }
+.nick5 { color: hsl(160, 50%, 60%); }
+.nick6 { color: hsl(200, 50%, 60%); }
+.nick7 { color: hsl(240, 50%, 60%); }
+.nick8 { color: hsl(280, 50%, 60%); }
+.nick9 { color: hsl(320, 50%, 60%); }
+
 TextInput, TextBrowser {
     border: none;
     color: #000000;

--- a/themes/dark/dark.css
+++ b/themes/dark/dark.css
@@ -28,6 +28,17 @@ a { color: #005fff; }
 .lightblue { color: #268bd2;}
 .pink { color: #6c71c4;}
 
+.nick0 { color: hsl(0, 0%, 60%); }
+.nick1 { color: hsl(0, 50%, 60%); }
+.nick2 { color: hsl(40, 50%, 60%); }
+.nick3 { color: hsl(80, 50%, 60%); }
+.nick4 { color: hsl(120, 50%, 60%); }
+.nick5 { color: hsl(160, 50%, 60%); }
+.nick6 { color: hsl(200, 50%, 60%); }
+.nick7 { color: hsl(240, 50%, 60%); }
+.nick8 { color: hsl(280, 50%, 60%); }
+.nick9 { color: hsl(320, 50%, 60%); }
+
 TextBrowser, TextInput {
     border: none;
     color: #eeeeec;

--- a/themes/material/material.css
+++ b/themes/material/material.css
@@ -28,6 +28,17 @@ a { color: #ff4081; }
 .lightblue { color: #268bd2;}
 .pink { color: #6c71c4;}
 
+.nick0 { color: hsl(0, 0%, 60%); }
+.nick1 { color: hsl(0, 50%, 60%); }
+.nick2 { color: hsl(40, 50%, 60%); }
+.nick3 { color: hsl(80, 50%, 60%); }
+.nick4 { color: hsl(120, 50%, 60%); }
+.nick5 { color: hsl(160, 50%, 60%); }
+.nick6 { color: hsl(200, 50%, 60%); }
+.nick7 { color: hsl(240, 50%, 60%); }
+.nick8 { color: hsl(280, 50%, 60%); }
+.nick9 { color: hsl(320, 50%, 60%); }
+
 TextInput, TextBrowser {
     font-family: "Open Sans";
     font-size: 14px;

--- a/themes/tomorrow/tomorrow.css
+++ b/themes/tomorrow/tomorrow.css
@@ -2,8 +2,8 @@ a { color: #81a2be; }
 .timestamp { color: #808080; font-size: small }
 
 .message { white-space: pre-wrap; }
-.notice { color: #b23e3e; }
-.action { color: #b232b2; }
+.notice { color: #de935f; }
+.action { color: #b294bb; }
 .event { color: #808080; }
 
 .bold { font-weight: bold; }
@@ -27,6 +27,17 @@ a { color: #81a2be; }
 .lightcyan { color: #8abeb7; /* 0C */ }
 .lightblue { color: #81a2be; /* 0D */ }
 .pink { color: #b294bb; /* 0E */ }
+
+.nick0 { color: #b4b7b4; /* 04 */ }
+.nick1 { color: #ffffff; /* 07 */ }
+.nick2 { color: #cc6666; /* 08 */ }
+.nick3 { color: #de935f; /* 09 */ }
+.nick4 { color: #f0c674; /* 0A */ }
+.nick5 { color: #b5bd68; /* 0B */ }
+.nick6 { color: #8abeb7; /* 0C */ }
+.nick7 { color: #81a2be; /* 0D */ }
+.nick8 { color: #b294bb; /* 0E */ }
+.nick9 { color: #a3685a; /* 0F */ }
 
 TextBrowser, TextInput {
     border: none;


### PR DESCRIPTION
This changes the nick coloring behavior to hash usernames into nine
buckets, (ten including a color unique to the user), and then passing
that bucket as a CSS class following the name "nick0".  Themes then
define color classes for "nick0" through "nick9".

The cute/dark theme colors use a similar HSL color selection process
from the old behavior, where each bucket represents one ninth of the
HSL color space (40° of the 360°).  The tomorrow theme instead uses
colors as specified in the Base16 standard.