### PR TITLE
Reload theme when changed

### DIFF
--- a/src/app/chatpage.cpp
+++ b/src/app/chatpage.cpp
@@ -118,6 +118,7 @@ void ChatPage::setTheme(const QString& theme)
 {
     if (!d.theme.isValid() || d.theme.name() != theme) {
         d.theme = ThemeLoader::instance()->theme(theme);
+        d.theme.reload();
 
         QString font = d.theme.font();
         if (!font.isEmpty())

--- a/src/libs/base/themeinfo.cpp
+++ b/src/libs/base/themeinfo.cpp
@@ -94,6 +94,7 @@ bool ThemeInfo::load(const QString& filePath)
 {
     QSettings settings(filePath, QSettings::IniFormat);
     d.path = QFileInfo(filePath).path();
+    d.filePath = filePath;
 
     QStringList groups = settings.childGroups();
     if (groups.contains("Theme")) {
@@ -108,4 +109,9 @@ bool ThemeInfo::load(const QString& filePath)
         settings.endGroup();
     }
     return isValid();
+}
+
+bool ThemeInfo::reload()
+{
+    return load(d.filePath);
 }

--- a/src/libs/base/themeinfo.h
+++ b/src/libs/base/themeinfo.h
@@ -36,6 +36,7 @@ class ThemeInfo
 public:
     bool isValid() const;
     bool load(const QString& filePath);
+    bool reload();
 
     QString name() const;
     QString author() const;
@@ -56,6 +57,7 @@ private:
         QString gtkTheme;
         QString font;
         QString path;
+        QString filePath;
     } d;
 };
 


### PR DESCRIPTION
ThemeInfo got a new pricate entry to remember the file it loaded, and a new method `reload()` that calls `load()` with
the original filename.