### PR TITLE
Allow ports below 1024, for example 443

### DIFF
--- a/src/app/connectpage.ui
+++ b/src/app/connectpage.ui
@@ -161,7 +161,7 @@
                </sizepolicy>
               </property>
               <property name="minimum">
-               <number>1024</number>
+               <number>0</number>
               </property>
               <property name="maximum">
                <number>65535</number>


### PR DESCRIPTION
makes no sense to limit the port number to above 1024

and yes, I run my znc on port 443