### PR TITLE
show - hide - raise on trayicon click

### DIFF
--- a/src/app/dock/dock.cpp
+++ b/src/app/dock/dock.cpp
@@ -213,8 +213,13 @@ void Dock::onTrayActivated(QSystemTrayIcon::ActivationReason reason)
             d.window->setVisible(!d.window->isVisible());
             break;
         case QSystemTrayIcon::Trigger:
-            d.window->raise();
-            d.window->activateWindow();
+            if (!d.window->isHidden() && (d.window->isMinimized() || d.window->isActiveWindow())) {
+                d.window->hide();
+            } else {
+                d.window->show();
+                d.window->raise();
+                d.window->activateWindow();
+            }
             break;
         default:
             break;


### PR DESCRIPTION
left click on the tray icon:
* if the window is shown and active, hide it
* if the window is shown but not active, raise/activate it
* if the window is hidden, show/raise/activate it