### PR TITLE
alt-1 to 9 moves to channel 1 to 9

### DIFF
--- a/src/app/tree/treewidget.cpp
+++ b/src/app/tree/treewidget.cpp
@@ -129,6 +129,13 @@ TreeWidget::TreeWidget(QWidget* parent) : QTreeWidget(parent)
     shortcut = new QShortcut(this);
     shortcut->setKey(QKeySequence(tr("Ctrl+R")));
     connect(shortcut, SIGNAL(activated()), this, SLOT(resetItems()));
+
+
+    for (int n=0; n<=9; n++) {
+        shortcut = new QShortcut(this);
+        shortcut->setKey(QKeySequence(navigate.arg(n)));
+        connect(shortcut, &QShortcut::activated, [=](){ this->moveToItem(n); });
+    }
 }
 
 IrcBuffer* TreeWidget::currentBuffer() const
@@ -756,4 +763,19 @@ QMenu* TreeWidget::createContextMenu(TreeItem* item)
     closeAction->setData(QVariant::fromValue(item));
 
     return menu;
+}
+
+void TreeWidget::moveToItem(int n)
+{
+    QTreeWidgetItem* firstConnection = topLevelItem(0);
+    if (firstConnection) {
+        if (n == 0) {
+            setCurrentItem(firstConnection);
+        } else {
+            QTreeWidgetItem* item = firstConnection->child(n-1);
+            if (item) {
+                setCurrentItem(item);
+            }
+        }
+    }
 }

--- a/src/app/tree/treewidget.h
+++ b/src/app/tree/treewidget.h
@@ -84,6 +84,7 @@ public slots:
     void expandCurrentConnection();
     void collapseCurrentConnection();
     void moveToMostActiveItem();
+    void moveToItem(int n);
 
 signals:
     void bufferAdded(IrcBuffer* buffer);


### PR DESCRIPTION
… of the first connection. that's how much is practical on the keyboard,
and people can always reorder theirs connections and channels.

alt-0 moves to the connection item itself

it's a bit crude and opinionated feature, but people can comment & improve on it