### PR TITLE
Add logger plugin

### DIFF
--- a/src/plugins/logger/logger.pro
+++ b/src/plugins/logger/logger.pro
@@ -1,0 +1,10 @@
+######################################################################
+# Communi
+######################################################################
+
+TEMPLATE = lib
+COMMUNI += core model
+CONFIG += communi_plugin
+
+HEADERS += $$PWD/loggerplugin.h
+SOURCES += $$PWD/loggerplugin.cpp

--- a/src/plugins/logger/loggerplugin.cpp
+++ b/src/plugins/logger/loggerplugin.cpp
@@ -1,0 +1,101 @@
+/*
+  Copyright (C) 2008-2017 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "loggerplugin.h"
+#include <IrcConnection>
+#include <IrcNetwork>
+#include <IrcMessage>
+#include <IrcCommand>
+#include <IrcChannel>
+#include <Irc>
+#include <QDir>
+#include <QTextStream>
+
+LoggerPlugin::LoggerPlugin(QObject* parent) : QObject(parent)
+    , m_logDirPath(QDir::homePath()+"/communilogs/")
+{
+    QDir logDir;
+    if (!logDir.exists(m_logDirPath))
+        logDir.mkpath(m_logDirPath);
+}
+
+LoggerPlugin::~LoggerPlugin()
+{
+}
+
+void LoggerPlugin::bufferAdded(IrcBuffer* buffer)
+{
+    // Do not log connection buffers and #magna
+    if (buffer->network()->name().isEmpty())
+        return;
+
+    const QString filename = logfileName(buffer);
+    writeToFile(filename, "=== Logfile started on " + timestamp() + " ===");
+
+    connect(buffer, SIGNAL(messageReceived(IrcMessage*)), this, SLOT(logMessage(IrcMessage*)));
+}
+
+void LoggerPlugin::bufferRemoved(IrcBuffer* buffer)
+{
+    disconnect(buffer, SIGNAL(messageReceived(IrcMessage*)), this, SLOT(logMessage(IrcMessage*)));
+}
+
+void LoggerPlugin::logMessage(IrcMessage *message)
+{
+    if (message->type() != IrcMessage::Private)
+        return;
+
+    IrcPrivateMessage *m = static_cast<IrcPrivateMessage*>(message);
+    const QString filename = logfileName(m);
+    writeToFile(filename , timestamp() + " " + m->nick() + ": " + m->content());
+}
+
+void LoggerPlugin::writeToFile(const QString &fileName, const QString &text)
+{
+    QFile logfile(m_logDirPath + fileName);
+    logfile.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text);
+
+    QTextStream ts(&logfile);
+    ts << text << endl;
+}
+
+QString LoggerPlugin::logfileName(IrcPrivateMessage *message) const
+{
+    return message->isPrivate() ? message->network()->name() + "_" + message->nick() + ".log"
+                                : message->network()->name() + "_" + message->target() + ".log";
+}
+
+QString LoggerPlugin::logfileName(IrcBuffer *buffer) const
+{
+    return buffer->network()->name() + "_" + buffer->title() + ".log";
+}
+
+QString LoggerPlugin::timestamp() const
+{
+    return QDateTime::currentDateTime().toString("[yyyy-MM-dd] hh:mm:ss");
+}

--- a/src/plugins/logger/loggerplugin.h
+++ b/src/plugins/logger/loggerplugin.h
@@ -1,0 +1,62 @@
+/*
+  Copyright (C) 2008-2017 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef LOGGERPLUGIN_H
+#define LOGGERPLUGIN_H
+
+#include <QtPlugin>
+#include <IrcMessageFilter>
+#include "bufferplugin.h"
+
+class IrcChannel;
+class IrcPrivateMessage;
+
+class LoggerPlugin : public QObject, public BufferPlugin
+{
+    Q_OBJECT
+    Q_INTERFACES(BufferPlugin)
+    Q_PLUGIN_METADATA(IID "Communi.BufferPlugin")
+
+public:
+    LoggerPlugin(QObject* parent = 0);
+    ~LoggerPlugin();
+    void bufferAdded(IrcBuffer* buffer);
+    void bufferRemoved(IrcBuffer* buffer);
+
+private slots:
+    void logMessage(IrcMessage *message);
+private:
+    void writeToFile(const QString &fileName, const QString &text);
+    QString logfileName(IrcPrivateMessage *message) const;
+    QString logfileName(IrcBuffer *buffer) const;
+    QString timestamp() const;
+
+    QString m_logDirPath;
+};
+
+#endif // LOGGERPLUGIN_H

--- a/src/plugins/plugins.pro
+++ b/src/plugins/plugins.pro
@@ -5,6 +5,7 @@
 TEMPLATE = subdirs
 SUBDIRS += away
 SUBDIRS += filter
+SUBDIRS += logger
 SUBDIRS += verifier
 SUBDIRS += znc
 SUBDIRS += messageseen


### PR DESCRIPTION
Submitting this PR to gather feedback on this. I wrote this plugin to store channels history in logfiles, as I need to grep things on them from time to time at work. After a few code modifications and weeks of tests, I thought it could be interesting to have this as part of communi.

As I said it works fine - I've been testing this for a while on Linux and Windows - however it needs polishing, for example there are hard coded things (e.g. dir logs are stored) and proper error handling is missing.