### PR TITLE
Remove leftover references to onBufferDestroyed

### DIFF
--- a/src/plugins/logger/loggerplugin.cpp
+++ b/src/plugins/logger/loggerplugin.cpp
@@ -94,7 +94,6 @@ void LoggerPlugin::bufferAdded(IrcBuffer* buffer)
         return;
 
     connect(buffer, SIGNAL(messageReceived(IrcMessage*)), this, SLOT(logMessage(IrcMessage*)));
-    connect(buffer, SIGNAL(destroyed()), this, SLOT(onBufferDestroyed()));
 
     const QString filename = logfileName(buffer);
     Item item;
@@ -109,7 +108,6 @@ void LoggerPlugin::bufferAdded(IrcBuffer* buffer)
 void LoggerPlugin::bufferRemoved(IrcBuffer* buffer)
 {
     disconnect(buffer, SIGNAL(messageReceived(IrcMessage*)), this, SLOT(logMessage(IrcMessage*)));
-    disconnect(buffer, SIGNAL(destroyed()), this, SLOT(onBufferDestroyed()));
 
     removeLogitemForBuffer(buffer);
 }


### PR DESCRIPTION
Remove references to onBufferDestroyed, removed in commit 7a1df7a.