### PR TITLE
Do not discard MainWindow close event

### DIFF
--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -47,7 +47,7 @@
 #include <QShortcut>
 #include <QSettings>
 #include <QMenuBar>
-#include <QTimer>
+#include <QThread>
 #include <QUuid>
 #include <QMenu>
 #include <QDir>
@@ -315,20 +315,19 @@ bool MainWindow::event(QEvent* event)
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
-    if (isVisible()) {
-        saveState();
-        d.save = false;
+    saveState();
+    d.save = false;
 
-        foreach (IrcConnection* connection, d.connections) {
-            connection->quit(qApp->property("description").toString());
-            connection->close();
-        }
-
-        // let the sessions close in the background
-        hide();
-        event->ignore();
-        QTimer::singleShot(1000, qApp, SLOT(quit()));
+    foreach (IrcConnection* connection, d.connections) {
+        connection->quit(qApp->property("description").toString());
+        connection->close();
     }
+
+    // let the sessions close in the background
+    hide();
+    QThread::sleep(1);
+    event->accept();
+    qApp->quit();
 }
 
 void MainWindow::showEvent(QShowEvent* event)


### PR DESCRIPTION
Discarding this event may be interpreted as if the application doesn't
want to close the window and demands user interaction

This cancels shutdown on KDE, for example, despite application silently
quitting afterwards

Some things I'm not sure about:
* I've removed check for `isVisible()` - I don't really understand what purpose did it serve. User can't really close invisible window and why would you call close on a hidden window and expect it behave differently? The only call to MainWindow::close() I've found is handling `Quit` shortcut.
* I've replaced quit timer with sleep. `IrcConnection` seems to be closing fine while main thread is asleep and I don't think we want any other UI interaction while the app is quitting.