### PR TITLE
use https for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/libs/base/shared"]
 	path = src/libs/base/shared
-	url = git://github.com/communi/communi-shared.git
+	url = https://github.com/communi/communi-shared.git


### PR DESCRIPTION
~HTTPS is more robust since it's blocked by barely any firewall.~
`git://` doesn't work anymore