### PR TITLE
Default to libera.chat and SSL.

### DIFF
--- a/src/app/connectpage.cpp
+++ b/src/app/connectpage.cpp
@@ -455,9 +455,9 @@ void ConnectPage::init(IrcConnection *connection)
     qsrand(QTime::currentTime().msec());
     ui.nickNameField->setPlaceholderText(tr("Communi%1").arg(qrand() % 9999));
     if (IrcConnection::isSecureSupported())
-        ui.serverField->setPlaceholderText(tr("irc.freenode.net +6697"));
+        ui.serverField->setPlaceholderText(tr("irc.libera.chat +6697"));
     else
-        ui.serverField->setPlaceholderText(tr("irc.freenode.net 6667"));
+        ui.serverField->setPlaceholderText(tr("irc.libera.chat 6667"));
 #endif // QT_VERSION
 
     connect(ui.buttonBox, SIGNAL(accepted()), ui.displayNameField, SLOT(setFocus()));

--- a/src/app/connectpage.ui
+++ b/src/app/connectpage.ui
@@ -116,7 +116,7 @@
           <item row="0" column="1">
            <widget class="QLineEdit" name="displayNameField">
             <property name="placeholderText">
-             <string>Freenode</string>
+             <string>Libera Chat</string>
             </property>
            </widget>
           </item>
@@ -136,7 +136,7 @@
              <set>Qt::ImhUrlCharactersOnly</set>
             </property>
             <property name="placeholderText">
-             <string>irc.freenode.net</string>
+             <string>irc.libera.chat</string>
             </property>
            </widget>
           </item>

--- a/src/app/connectpage.ui
+++ b/src/app/connectpage.ui
@@ -167,7 +167,7 @@
                <number>65535</number>
               </property>
               <property name="value">
-               <number>6667</number>
+               <number>6697</number>
               </property>
              </widget>
             </item>
@@ -175,6 +175,9 @@
              <widget class="QCheckBox" name="secureBox">
               <property name="text">
                <string>&amp;Secure</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
When testing[ my Debian package of libcommuni[1] I figures out that communi-desktop still defaults to freenode and non-SSL connections.

This little PR should rectify that.


[1] ITP bug https://bugs.debian.org/1016726 ; It is currently waiting for Debian FTP Masters approval.